### PR TITLE
Prepare for 0.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2] - 2022-01-05
+- Change react target to `es2021` ([#3](https://github.com/STORIS/tsconfig/pull/3))
+
 ## [0.0.1] - 2022-01-05
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/storis/tsconfig/compare/0.0.1...HEAD
-[0.0.1]: https://github.com/storis/eslint-config/releases/tag/0.0.1
+[Unreleased]: https://github.com/storis/tsconfig/compare/0.0.2...HEAD
+[0.0.2]: https://github.com/storis/tsconfig/compare/0.0.1...0.0.2
+[0.0.1]: https://github.com/storis/tsconfig/releases/tag/0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storis/tsconfig",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storis/tsconfig",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "4.5.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storis/tsconfig",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "STORIS TypeScript Configurations",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR prepares for 0.0.2 release by bumping the version and updating the CHANGELOG.