### PR TITLE
Update editorconfig to include cjs and mjs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ insert_final_newline = true
 # unset will result in using the editor default
 [*.md]
 trim_trailing_whitespace = false
-[*.{js,jsx,ts,d.ts,css,html}]
+[*.{cjs,mjs,js,jsx,ts,d.ts,css,html}]
 indent_style = tab
 indent_size = unset

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,29 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":onlyNpm",
+    ":automergeTypes",
+    ":automergeMinor",
+    ":rebaseStalePrs",
+    ":prHourlyLimit4",
+    ":label(dependencies)"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "rangeStrategy": "pin"
+    },
+    {
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "widen"
+    },
+    {
+      "matchDepTypes": ["engines"],
+      "rangeStrategy": "auto"
+    }
   ]
 }


### PR DESCRIPTION
This PR updates editorconfig to include `cjs` and `mjs` overrides to ensure that tabs are used.

Additionally, the renovate configuration was updated to the standard structure to allow for auto merging and semver bumps on production dependencies.