### PR TITLE
Skip status checks since repo has no CI

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     ":onlyNpm",
     ":automergeTypes",
     ":automergeMinor",
+    ":skipStatusChecks",
     ":rebaseStalePrs",
     ":prHourlyLimit4",
     ":label(dependencies)"


### PR DESCRIPTION
This PR adjusts renovate to skip status checks since there are no CI runs configured for the repo.