### PR TITLE
Update support for Node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Add the following to your typescript configuration file (e.g. `tsconfig.json`):
 }
 ```
 
+#### Node 18
+Add the following to your typescript configuration file (e.g. `tsconfig.json`):
+```
+{
+  "extends": "@storis/tsconfig/node18/tsconfig.json",
+}
+```
+
 #### React
 Add the following to your typescript configuration file (e.g. `tsconfig.json`):
 ```

--- a/node18/tsconfig.json
+++ b/node18/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../base/tsconfig.json",
+  "compilerOptions": {
+    /* Language and Environment */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["es2022"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "typescript": "4.6.4"
       },
       "engines": {
-        "node": "^16.0.0",
+        "node": "^16.0.0 || ^18.0.0",
         "typescript": "^4.5.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/STORIS/tsconfig#readme",
   "engines": {
-    "node": "^16.0.0",
+    "node": "^16.0.0 || ^18.0.0",
     "typescript": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR augments the `engines` property of `package.json` to support `^18.0.0` as well as `^16.0.0`.  Additionally, it adds a new node 18 configuration.