### PR TITLE
Prepare for 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,13 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2022-05-13
+
+This release changes the version to 1.0.0 only so it can more easily align with semantic versioning in the future. It does not contain any breaking changes.
+
+### Added
+
+- Add `node18` configuration and update engines to indicate node 18 support ([#11](https://github.com/STORIS/tsconfig/pull/11))
+
 ## [0.0.2] - 2022-01-05
+
+### Changed
+
 - Change react target to `es2021` ([#3](https://github.com/STORIS/tsconfig/pull/3))
 
 ## [0.0.1] - 2022-01-05
+
 ### Added
+
 - Initial release
 
-[Unreleased]: https://github.com/storis/tsconfig/compare/0.0.2...HEAD
+[unreleased]: https://github.com/storis/tsconfig/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/storis/tsconfig/compare/0.0.2...1.0.0
 [0.0.2]: https://github.com/storis/tsconfig/compare/0.0.1...0.0.2
 [0.0.1]: https://github.com/storis/tsconfig/releases/tag/0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storis/tsconfig",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storis/tsconfig",
-      "version": "0.0.2",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "4.6.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storis/tsconfig",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "STORIS TypeScript Configurations",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR prepares for the 1.0.0 release by bumping the version and updating the CHANGELOG.